### PR TITLE
server edit, make url field have url keyboard type

### DIFF
--- a/Classes/View Controllers/Settings/ServerEditViewController.swift
+++ b/Classes/View Controllers/Settings/ServerEditViewController.swift
@@ -64,7 +64,7 @@ import CocoaLumberjackSwift
         urlField.delegate = self
         urlField.backgroundColor = .white
         urlField.textColor = .black
-        urlField.keyboardType = .default
+        urlField.keyboardType = .URL
         urlField.textContentType = .URL
         urlField.autocapitalizationType = .none
         urlField.autocorrectionType = .no


### PR DESCRIPTION
This PR changes the keyboard type of the URL field in the app's initial server configuration screen to `.URL`. This makes it a lot easier to enter the URL.