### PR TITLE
fix transparent current playlist view controller nav bar

### DIFF
--- a/Classes/View Controllers/Player/CurrentPlaylistViewController.m
+++ b/Classes/View Controllers/Player/CurrentPlaylistViewController.m
@@ -60,7 +60,12 @@ LOG_LEVEL_ISUB_DEFAULT
     self.view.backgroundColor = [UIColor colorNamed:@"isubBackgroundColor"];
     self.title = @"Play Queue";
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Done" style:UIBarButtonItemStyleDone target:self action:@selector(dismiss:)];
-	
+    UINavigationBarAppearance* appearance = [[UINavigationBarAppearance alloc] init];
+    [appearance configureWithOpaqueBackground];
+    self.navigationItem.compactAppearance = appearance;
+    self.navigationItem.standardAppearance = appearance;
+    self.navigationItem.scrollEdgeAppearance = appearance;
+
     [self registerForNotifications];
 				
     // Setup header view


### PR DESCRIPTION
This PR fixes a bug where the navigation bar above the current playlist was transparent and so was hard to see. (Perhaps the bug only manifests itself when you're building in a current version of Xcode, but no matter.)

## How to test

Add something to the queue and start playing it. OK, you can stop playing it now; the point is that you are now on the player screen for that song. Tap the queue icon at the top right. You are now on the screen in question! Previously, the words "Done" and "Play Queue" were hard to see because the nav bar surrounding them was transparent. Now they aren't. This is what it looks like now on my device:

![Screenshot 2023-12-18 at 10 47 11](https://github.com/einsteinx2/iSubMusicStreamer/assets/838939/6aae4ff7-2dd0-43d7-ad27-54668560a5ae)

I'm not sure what the intended background color was, but this looks good and harmonizes with the rest of the view in both light and dark mode.
