### PR TITLE
Fix warnings

### DIFF
--- a/Classes/Audio Engine/BassGaplessPlayer.m
+++ b/Classes/Audio Engine/BassGaplessPlayer.m
@@ -231,8 +231,8 @@ DWORD CALLBACK MyFileReadProc(void *buffer, DWORD length, void *user)
 	}
 }
 
-BOOL CALLBACK MyFileSeekProc(QWORD offset, void *user)
-{	
+BOOL32 CALLBACK MyFileSeekProc(QWORD offset, void *user)
+{
 	if (user == NULL)
 		return NO;
 	

--- a/Classes/Main/ObjC.swift
+++ b/Classes/Main/ObjC.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-public struct NSExceptionError: Error, CustomStringConvertible {
+public struct NSExceptionError: Error, CustomStringConvertible, @unchecked Sendable {
     public let exception: NSException
 
     public init(exception: NSException) {

--- a/Classes/Models/Loaders/SUSCoverArtLoader.m
+++ b/Classes/Models/Loaders/SUSCoverArtLoader.m
@@ -22,7 +22,7 @@ static NSMutableArray *_loadingImageNames;
 static NSObject *_syncObject;
 
 __attribute__((constructor))
-static void initialize_navigationBarImages() {
+static void initialize_navigationBarImages(void) {
 	_loadingImageNames = [[NSMutableArray alloc] init];
 	_syncObject = [[NSObject alloc] init];
 }

--- a/Classes/Models/Singletons/SavedSettings.m
+++ b/Classes/Models/Singletons/SavedSettings.m
@@ -859,7 +859,7 @@ LOG_LEVEL_ISUB_DEFAULT
 	// Load the servers array
     NSData *servers = [_userDefaults objectForKey:@"servers"];
     if (servers) {
-        NSSet *classes = [NSSet setWithArray:@[NSArray.class, ISMSServer.class]];
+        NSSet *classes = [NSSet setWithArray:@[NSArray.class, ISMSServer.class, NSString.class]];
         self.serverList = [[NSKeyedUnarchiver unarchivedObjectOfClasses:classes fromData:servers error:nil] mutableCopy];
     }
 }

--- a/Classes/View Controllers/Settings/ServerListViewController.m
+++ b/Classes/View Controllers/Settings/ServerListViewController.m
@@ -51,7 +51,9 @@ LOG_LEVEL_ISUB_DEFAULT
     self.navigationItem.rightBarButtonItem = self.editButtonItem;
 	
     if (settingsS.serverList == nil || [settingsS.serverList count] == 0) {
-		[self addAction:nil];
+        [EX2Dispatch runInMainThreadAfterDelay:0.3 block:^{
+            [self addAction:nil];
+        }];
     }
 	
     self.segmentControlContainer = [[UIView alloc] init];

--- a/Classes/View Controllers/Tabs/Chat/ChatViewController.m
+++ b/Classes/View Controllers/Tabs/Chat/ChatViewController.m
@@ -218,8 +218,8 @@
 	NSDate *date = [NSDate dateWithTimeIntervalSince1970:unixtime];
 	
 	NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-	formatter.dateStyle = kCFDateFormatterShortStyle;
-	formatter.timeStyle = kCFDateFormatterShortStyle;
+	formatter.dateStyle = NSDateFormatterShortStyle;
+	formatter.timeStyle = NSDateFormatterShortStyle;
 	formatter.locale = [NSLocale currentLocale];
 	NSString *formattedDate = [formatter stringFromDate:date];
 	


### PR DESCRIPTION
This PR fixes all compile-time warnings (except for one that's inside GCDWebServer, nothing we can do about that) and several run-time warnings that manifest themselves at launch time.

In _BassGaplessPlayer.m_ I have changed BOOL to BOOL32 because I have updated LibBASS. That update appears in a different PR. If you want this to compile without merging that PR first, just change BOOL32 back to BOOL.