### PR TITLE
fix call-super and related howlers

### DIFF
--- a/Classes/View Controllers/LicensesViewController.swift
+++ b/Classes/View Controllers/LicensesViewController.swift
@@ -14,6 +14,7 @@ import SnapKit
     let webView = WKWebView()
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneAction))
         
         webView.allowsBackForwardNavigationGestures = true

--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.m
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.m
@@ -223,6 +223,7 @@
 }
 
 - (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear: animated];
 	if (settingsS.isShouldShowEQViewInstructions) {
         NSString *message = @"Double tap to create a new EQ point and double tap any existing EQ points to remove them.";
         UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Instructions" message:message preferredStyle:UIAlertControllerStyleAlert];
@@ -289,6 +290,7 @@
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear: animated];
 	[NSNotificationCenter removeObserverOnMainThread:self name:ISMSNotification_BassEffectPresetLoaded];
 	[NSNotificationCenter removeObserverOnMainThread:self name:@"hidePresetPicker"];
 	[self removeEqViews];

--- a/Classes/View Controllers/Player/Page Control/CacheStatusViewController.swift
+++ b/Classes/View Controllers/Player/Page Control/CacheStatusViewController.swift
@@ -37,6 +37,7 @@ final class CacheStatusViewController: UIViewController {
     }
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         view.backgroundColor = .black
         
         let titleLabel = UILabel()

--- a/Classes/View Controllers/Player/Page Control/SongInfoViewController.swift
+++ b/Classes/View Controllers/Player/Page Control/SongInfoViewController.swift
@@ -14,6 +14,7 @@ final class SongInfoViewController: UIViewController {
     var realTimeBitrateLabel: UILabel?
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         view.backgroundColor = .black
         
         let titleLabel = UILabel()
@@ -56,7 +57,7 @@ final class SongInfoViewController: UIViewController {
     }
     
     override func viewWillDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+        super.viewWillDisappear(animated)
         stopUpdatingRealtimeBitrate()
         NotificationCenter.removeObserverOnMainThread(self, name: ISMSNotification_SongPlaybackStarted)
     }

--- a/Classes/View Controllers/Settings/ServerEditViewController.swift
+++ b/Classes/View Controllers/Settings/ServerEditViewController.swift
@@ -25,6 +25,7 @@ import CocoaLumberjackSwift
     }
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         view.backgroundColor = .black
         view.overrideUserInterfaceStyle = .dark
         

--- a/Classes/View Controllers/Settings/SettingsTabViewController.m
+++ b/Classes/View Controllers/Settings/SettingsTabViewController.m
@@ -96,7 +96,7 @@ LOG_LEVEL_ISUB_DEFAULT
         [self.quickSkipSegmentControl setTitleTextAttributes:@{NSFontAttributeName: [UIFont systemFontOfSize:11]} forState:UIControlStateNormal];
     }
 	
-	[self.cacheSpaceLabel2 addTarget:self action:@selector(textFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
+	[self.cacheSpaceLabel2 addTarget:self action:@selector(updateCacheSpaceSlider) forControlEvents:UIControlEventEditingChanged];
     
     self.maxVideoBitrate3GSegmentedControl.selectedSegmentIndex = settingsS.maxVideoBitrate3G;
     self.maxVideoBitrateWifiSegmentedControl.selectedSegmentIndex = settingsS.maxVideoBitrateWifi;

--- a/Classes/View Controllers/Tabs/Bookmarks/BookmarksViewController.m
+++ b/Classes/View Controllers/Tabs/Bookmarks/BookmarksViewController.m
@@ -68,7 +68,10 @@
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    
+    [self doViewWillAppearTasks];
+}
+
+- (void)doViewWillAppearTasks {
     [self addURLRefBackButton];
 	
     self.navigationItem.rightBarButtonItem = nil;
@@ -224,6 +227,7 @@
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear: animated];
 	self.bookmarkIds = nil;
 }
 
@@ -289,7 +293,7 @@
 		
 		// Reload the table
 		//[self.tableView reloadData];
-		[self viewWillAppear:NO];
+		[self doViewWillAppearTasks];
 	}
 }
 

--- a/Classes/View Controllers/Tabs/Chat/ChatViewController.m
+++ b/Classes/View Controllers/Tabs/Chat/ChatViewController.m
@@ -119,6 +119,7 @@
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear: animated];
 	if (self.isNoChatMessagesScreenShowing == YES) {
 		[self.noChatMessagesScreen removeFromSuperview];
 		self.isNoChatMessagesScreenShowing = NO;

--- a/Classes/View Controllers/Tabs/Genre/GenresViewController.m
+++ b/Classes/View Controllers/Tabs/Genre/GenresViewController.m
@@ -102,6 +102,7 @@
 
 
 - (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear: animated];
 	if (self.isNoGenresScreenShowing == YES) {
 		[self.noGenresScreen removeFromSuperview];
 		self.isNoGenresScreenShowing = NO;

--- a/Classes/View Controllers/Tabs/Playing/PlayingViewController.m
+++ b/Classes/View Controllers/Tabs/Playing/PlayingViewController.m
@@ -78,6 +78,7 @@
 }
 
 -(void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear: animated];
 	if (self.isNothingPlayingScreenShowing) {
 		[self.nothingPlayingScreen removeFromSuperview];
 		self.isNothingPlayingScreenShowing = NO;


### PR DESCRIPTION
This PR fixes a few call-super howlers (i.e. places where we are supposed to call `super` but are failing to do so), along with a couple of places I noticed (there may be more) where we were directly calling methods that belong only to Apple to call.