### PR TITLE
improve auto scrolling label

### DIFF
--- a/Classes/View Controllers/Player/CurrentPlaylistViewController.m
+++ b/Classes/View Controllers/Player/CurrentPlaylistViewController.m
@@ -176,12 +176,14 @@ LOG_LEVEL_ISUB_DEFAULT
 - (void)viewWillAppear:(BOOL)animated  {
 	[super viewWillAppear:animated];
 	
+    [NSNotificationCenter postNotificationToMainThreadWithName: @"playlistAppearing"];
 	[self selectRow];
 }
 
 - (void)viewWillDisappear:(BOOL)animated  {
     [super viewWillDisappear:animated];
 	
+    [NSNotificationCenter postNotificationToMainThreadWithName: @"playlistDisappearing"];
 	[self unregisterForNotifications];
 
 	if (self.isEditing) {

--- a/Classes/View Controllers/Player/PlayerViewController.swift
+++ b/Classes/View Controllers/Player/PlayerViewController.swift
@@ -29,8 +29,8 @@ import CocoaLumberjackSwift
     
     // Song info
     private let songInfoContainer = UIView()
-    private let songNameLabel = AutoScrollingLabel()
-    private let artistNameLabel = AutoScrollingLabel()
+    private let songNameLabel = AutoScrollingLabel(centerIfPossible: true)
+    private let artistNameLabel = AutoScrollingLabel(centerIfPossible: true)
     
     // Player controls
     private let controlsStack = UIStackView()
@@ -170,8 +170,7 @@ import CocoaLumberjackSwift
         songInfoContainer.addSubview(songNameLabel)
         songNameLabel.snp.makeConstraints { make in
             make.height.equalToSuperview().multipliedBy(0.6)
-            make.width.lessThanOrEqualToSuperview()
-            make.centerX.top.equalToSuperview()
+            make.leading.trailing.top.equalToSuperview()
         }
         
         artistNameLabel.font = .boldSystemFont(ofSize: UIDevice.isSmall() || UIDevice.isPad() ? 18 : 16)
@@ -179,8 +178,7 @@ import CocoaLumberjackSwift
         songInfoContainer.addSubview(artistNameLabel)
         artistNameLabel.snp.makeConstraints { make in
             make.height.equalToSuperview().multipliedBy(0.4)
-            make.width.lessThanOrEqualToSuperview()
-            make.centerX.bottom.equalToSuperview()
+            make.leading.trailing.bottom.equalToSuperview()
         }
         
         //
@@ -226,7 +224,6 @@ import CocoaLumberjackSwift
         downloadProgressView.backgroundColor = UIColor.systemGray4
         progressBarContainer.insertSubview(downloadProgressView, belowSubview: progressSlider)
         downloadProgressView.snp.makeConstraints { make in
-//            make.width.equalTo(0)
             make.width.equalTo(0)
             make.leading.equalTo(progressSlider).offset(-5)
             make.top.equalTo(progressSlider).offset(-3)

--- a/Classes/View Controllers/Table Cells/AutoScrollingLabel.swift
+++ b/Classes/View Controllers/Table Cells/AutoScrollingLabel.swift
@@ -226,7 +226,7 @@ private let labelGap = 25.0
         //       the backgorund, whenever the song would change, it would kick off the
         //       animations again which would short-circuit and eat up CPU.
         //       This check prevents any animation while in the background.
-        guard UIApplication.shared.applicationState != .background else { return }
+        guard UIApplication.shared.applicationState == .active else { return }
         guard !isScrolling else { return }
 
         createAnimator(delay: delay)


### PR DESCRIPTION
This PR tackles a number of issue connected with the auto scrolling label:

* There were some circumstances where the auto scrolling label would keep scrolling even though it was in the "background"; this PR stops the scrolling during those circumstances.
* The entire layout of the auto scrolling label was deeply troubled. The problem stemmed from three sources (and this PR makes revisions with respect to all of them):
    * Some instances of auto scrolling label, but not all, need to display their text centered if it isn't long enough to scroll.
    * Some instance of auto scrolling label, but not, need to be able to change their contents "live".
    * There was a misunderstanding about what a scroll view's content view is for and how to use it correctly.
* Due to a bug, the temporal gap between scrolls could get longer and longer as time went by. This PR fixes that.
* Some efficiencies are also introduced.
