### PR TITLE
Feature/suffle improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ sqlcipher/Makefile
 sqlcipher/config.log
 sqlcipher/config.status
 sqlcipher/libtool
+iSub.xcodeproj/project.pbxproj
+iSub.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/Classes/Models/Data Store/BookmarkStore.swift
+++ b/Classes/Models/Data Store/BookmarkStore.swift
@@ -61,7 +61,7 @@ extension Store {
                 let bookmark = Bookmark(id: nextBookmarkId, song: song, localPlaylist: playlist, songIndex: songIndex, offsetInSeconds: offsetInSeconds, offsetInBytes: offsetInBytes)
 
                 // Add the songs from current play queue to the new playlist
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT serverId, songId
                     FROM localPlaylistSong
                     WHERE localPlaylistId = \(playQueue.currentPlaylistId)

--- a/Classes/Models/Data Store/DownloadsStore.swift
+++ b/Classes/Models/Data Store/DownloadsStore.swift
@@ -49,7 +49,7 @@ extension DownloadedSong: FetchableRecord, PersistableRecord {
     }
     
     static func downloadedSongs(serverId: Int, level: Int, parentPathComponent: String) -> SQLRequest<DownloadedSong> {
-        let sql: SQLLiteral = """
+        let sql: SQL = """
             SELECT *
             FROM \(DownloadedSong.self)
             JOIN \(DownloadedSongPathComponent.self)
@@ -65,7 +65,7 @@ extension DownloadedSong: FetchableRecord, PersistableRecord {
     }
     
     static func downloadedSongs(downloadedTagArtist: DownloadedTagArtist) -> SQLRequest<DownloadedSong> {
-        let sql: SQLLiteral = """
+        let sql: SQL = """
             SELECT *
             FROM \(DownloadedSong.self)
             JOIN \(Song.self)
@@ -79,7 +79,7 @@ extension DownloadedSong: FetchableRecord, PersistableRecord {
     }
     
     static func downloadedSongs(downloadedTagAlbum: DownloadedTagAlbum) -> SQLRequest<DownloadedSong> {
-        let sql: SQLLiteral = """
+        let sql: SQL = """
             SELECT *
             FROM \(DownloadedSong.self)
             JOIN \(Song.self)
@@ -133,7 +133,7 @@ extension DownloadedFolderArtist: FetchableRecord, PersistableRecord {
 
 extension DownloadedFolderAlbum: FetchableRecord, PersistableRecord {
     static func downloadedFolderAlbums(serverId: Int, level: Int, parentPathComponent: String) -> SQLRequest<DownloadedFolderAlbum> {
-        let sql: SQLLiteral = """
+        let sql: SQL = """
             SELECT \(DownloadedSongPathComponent.self).serverId,
                 \(DownloadedSongPathComponent.self).level,
                 \(DownloadedSongPathComponent.self).pathComponent AS name,
@@ -159,7 +159,7 @@ extension DownloadedTagArtist: FetchableRecord, PersistableRecord {
 extension DownloadedTagAlbum: FetchableRecord, PersistableRecord {
     // TODO: Check query plan and try different join orders and group by tables to see which is fastest (i.e. TagAlbum.id vs Song.tagAlbumId)
     static func downloadedTagAlbums(downloadedTagArtist: DownloadedTagArtist) -> SQLRequest<DownloadedTagAlbum> {
-        let sql: SQLLiteral = """
+        let sql: SQL = """
             SELECT \(TagAlbum.self).*
             FROM \(DownloadedSong.self)
             JOIN \(Song.self)
@@ -181,7 +181,7 @@ extension Store {
 //    func downloadedFolderArtists() -> [DownloadedFolderArtist] {
 //        do {
 //            return try pool.read { db in
-//                let sql: SQLLiteral = """
+//                let sql: SQL = """
 //                    SELECT serverId, pathComponent AS name
 //                    FROM \(DownloadedSongPathComponent.self)
 //                    WHERE level = 0
@@ -198,7 +198,7 @@ extension Store {
     func downloadedFolderArtists(serverId: Int) -> [DownloadedFolderArtist] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT serverId, pathComponent AS name
                     FROM \(DownloadedSongPathComponent.self)
                     WHERE serverId = \(serverId) AND level = 0
@@ -216,7 +216,7 @@ extension Store {
 //    func downloadedFolderAlbums(level: Int) -> [DownloadedFolderArtist] {
 //        do {
 //            return try pool.read { db in
-//                let sql: SQLLiteral = """
+//                let sql: SQL = """
 //                    SELECT serverId, level, pathComponent AS name
 //                    FROM \(DownloadedSongPathComponent.self)
 //                    WHERE serverId = \(serverId) AND level = \(level)
@@ -278,7 +278,7 @@ extension Store {
     func downloadedTagArtists(serverId: Int) -> [DownloadedTagArtist] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT \(TagArtist.self).*
                     FROM \(DownloadedSong.self)
                     JOIN \(Song.self)
@@ -303,7 +303,7 @@ extension Store {
     func downloadedTagAlbums(serverId: Int) -> [DownloadedTagAlbum] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT \(TagAlbum.self).*
                     FROM \(DownloadedSong.self)
                     JOIN \(Song.self)
@@ -353,7 +353,7 @@ extension Store {
     func songsRecursive(serverId: Int, level: Int, parentPathComponent: String) -> [Song] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM \(Song.self)
                     JOIN \(DownloadedSongPathComponent.self)
@@ -382,7 +382,7 @@ extension Store {
     func songsRecursive(downloadedTagArtist: DownloadedTagArtist) -> [Song] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM \(Song.self)
                     JOIN \(DownloadedSong.self)
@@ -403,7 +403,7 @@ extension Store {
     func songsRecursive(downloadedTagAlbum: DownloadedTagAlbum) -> [Song] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM \(Song.self)
                     JOIN \(DownloadedSong.self)
@@ -534,7 +534,7 @@ extension Store {
     func downloadedSongs(serverId: Int) -> [DownloadedSong] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM \(DownloadedSong.self)
                     ORDER BY \(DownloadedSong.self).downloadedDate COLLATE NOCASE DESC
@@ -563,7 +563,7 @@ extension Store {
     func oldestDownloadedSongByDownloadedDate() -> DownloadedSong? {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM \(DownloadedSong.self)
                     WHERE isFinished = 1 AND isPinned = 0
@@ -582,7 +582,7 @@ extension Store {
     func oldestDownloadedSongByPlayedDate() -> DownloadedSong? {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM \(DownloadedSong.self)
                     WHERE isFinished = 1 AND isPinned = 0
@@ -629,7 +629,7 @@ extension Store {
     func deleteDownloadedSongs(serverId: Int, level: Int) -> Bool {
         do {
             return try pool.write { db in
-                let songIdsSql: SQLLiteral = """
+                let songIdsSql: SQL = """
                     SELECT songId
                     FROM \(DownloadedSongPathComponent.self)
                     WHERE serverId = \(serverId) AND level = \(level)
@@ -722,7 +722,7 @@ extension Store {
     func update(playedDate: Date, serverId: Int, songId: String) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     UPDATE \(DownloadedSong.self)
                     SET playedDate = \(playedDate)
                     WHERE serverId = \(serverId) AND songId = \(songId)
@@ -743,7 +743,7 @@ extension Store {
     func update(downloadFinished: Bool, serverId: Int, songId: String) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     UPDATE \(DownloadedSong.self)
                     SET isFinished = \(downloadFinished)
                     WHERE serverId = \(serverId) AND songId = \(songId)
@@ -769,7 +769,7 @@ extension Store {
     func update(isPinned: Bool, serverId: Int, songId: String) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     UPDATE \(DownloadedSong.self)
                     SET isPinned = \(isPinned)
                     WHERE serverId = \(serverId) AND songId = \(songId)
@@ -790,7 +790,7 @@ extension Store {
     func isDownloadFinished(serverId: Int, songId: String) -> Bool {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT isFinished
                     FROM \(DownloadedSong.self)
                     WHERE serverId = \(serverId) AND songId = \(songId)
@@ -810,7 +810,7 @@ extension Store {
     func addToDownloadQueue(serverId: Int, songId: String) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT OR IGNORE INTO downloadQueue (serverId, songId, queuedDate)
                     VALUES (\(serverId), \(songId), \(Date()))
                     """
@@ -832,7 +832,7 @@ extension Store {
         do {
             return try pool.write { db in
                 for songId in songIds {
-                    let sql: SQLLiteral = """
+                    let sql: SQL = """
                         INSERT OR IGNORE INTO downloadQueue (serverId, songId)
                         VALUES (\(serverId), \(songId)
                         """
@@ -865,7 +865,7 @@ extension Store {
     func removeFromDownloadQueue(serverId: Int, songId: String) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     DELETE FROM downloadQueue
                     WHERE serverId = (\(serverId) AND songId = \(songId))
                     """
@@ -887,7 +887,7 @@ extension Store {
     func songFromDownloadQueue(position: Int) -> Song? {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM \(Song.self)
                     JOIN downloadQueue
@@ -906,7 +906,7 @@ extension Store {
     func queuedDateForSongFromDownloadQueue(position: Int) -> Date? {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT queuedDate
                     FROM downloadQueue
                     ORDER BY downloadQueue.rowid ASC
@@ -923,7 +923,7 @@ extension Store {
     func isSongInDownloadQueue(song: Song) -> Bool {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT songId
                     FROM downloadQueue
                     WHERE downloadQueue.serverId = \(song.serverId) AND downloadQueue.songId = \(song.id)

--- a/Classes/Models/Data Store/FolderAlbumStore.swift
+++ b/Classes/Models/Data Store/FolderAlbumStore.swift
@@ -112,7 +112,7 @@ extension Store {
     func folderAlbumIds(serverId: Int, parentFolderId: String) -> [String] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT folderId
                     FROM folderAlbumList
                     WHERE serverId = \(serverId) AND parentFolderId = \(parentFolderId)
@@ -144,7 +144,7 @@ extension Store {
                 try folderAlbum.save(db)
                 
                 // Insert folder id into list cache
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO folderAlbumList
                     (serverId, parentFolderId, folderId)
                     VALUES (\(folderAlbum.serverId), \(folderAlbum.parentFolderId), \(folderAlbum.id))
@@ -161,7 +161,7 @@ extension Store {
     func songIds(serverId: Int, parentFolderId: String) -> [String] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT songId
                     FROM folderSongList
                     WHERE serverId = \(serverId) AND parentFolderId = \(parentFolderId)
@@ -187,7 +187,7 @@ extension Store {
                 try song.save(db)
                 
                 // Insert song id into list cache
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO folderSongList
                     (serverId, parentFolderId, songId)
                     VALUES (\(song.serverId), \(parentFolderId), \(song.id))

--- a/Classes/Models/Data Store/FolderArtistStore.swift
+++ b/Classes/Models/Data Store/FolderArtistStore.swift
@@ -84,7 +84,7 @@ extension Store {
     func folderArtistIds(serverId: Int, mediaFolderId: Int) -> [String] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT folderArtistId
                     FROM folderArtistList
                     WHERE serverId = \(serverId) AND mediaFolderId = \(mediaFolderId)
@@ -116,7 +116,7 @@ extension Store {
                 try folderArtist.save(db)
                 
                 // Insert artist id into list cache
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO folderArtistList
                     (serverId, mediaFolderId, folderArtistId)
                     VALUES (\(folderArtist.serverId), \(mediaFolderId), \(folderArtist.id))
@@ -133,7 +133,7 @@ extension Store {
     func folderArtistSections(serverId: Int, mediaFolderId: Int) -> [TableSection] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM folderArtistTableSection
                     WHERE serverId = \(serverId) AND mediaFolderId = \(mediaFolderId)
@@ -150,7 +150,7 @@ extension Store {
         do {
             return try pool.write { db in
                 // Insert artist id into list cache
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO folderArtistTableSection
                     (serverId, mediaFolderId, name, position, itemCount)
                     VALUES (\(section.serverId), \(section.mediaFolderId), \(section.name), \(section.position), \(section.itemCount))
@@ -167,7 +167,7 @@ extension Store {
     func folderArtistMetadata(serverId: Int, mediaFolderId: Int) -> RootListMetadata? {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM folderArtistListMetadata
                     WHERE serverId = \(serverId) AND mediaFolderId = \(mediaFolderId)
@@ -183,7 +183,7 @@ extension Store {
     func add(folderArtistListMetadata metadata: RootListMetadata) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO folderArtistListMetadata
                     (serverId, mediaFolderId, itemCount, reloadDate)
                     VALUES (\(metadata.serverId), \(metadata.mediaFolderId), \(metadata.itemCount), \(metadata.reloadDate))
@@ -202,7 +202,7 @@ extension Store {
         do {
             return try pool.read { db in
                 let searchTerm = "%\(name)%"
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT folderArtistId
                     FROM folderArtistList
                     JOIN \(FolderArtist.self)

--- a/Classes/Models/Data Store/LocalPlaylistStore.swift
+++ b/Classes/Models/Data Store/LocalPlaylistStore.swift
@@ -487,7 +487,7 @@ extension Store {
             // Fill the play queue
             try pool.write { db in
                 // Add the songs from the playlist to the play queue
-                // NOTE: This is NOT an SQLLiteral as that string interpolation doesn't work in the SELECT statement.
+                // NOTE: This is NOT an SQL as that string interpolation doesn't work in the SELECT statement.
                 //       There is no security risk directly interpolating the values here as they are integers and
                 //       there is no posibility of SQL injection. Plus the values come from the code not user input.
                 let sql = """

--- a/Classes/Models/Data Store/LocalPlaylistStore.swift
+++ b/Classes/Models/Data Store/LocalPlaylistStore.swift
@@ -415,8 +415,7 @@ extension Store {
     func createShuffleQueue(currentPosition: Int) -> Bool {
         do {
             // Clear the existing shuffle play queue playlist
-            clearPlayQueue()
-            //clear(localPlaylistId: LocalPlaylist.Default.shuffleQueueId)
+            clear(localPlaylistId: LocalPlaylist.Default.shuffleQueueId)
             
             try pool.write { db in
                 //Insert current playing song into the localPlaylistSong at the first position

--- a/Classes/Models/Data Store/LyricsStore.swift
+++ b/Classes/Models/Data Store/LyricsStore.swift
@@ -59,7 +59,7 @@ extension Store {
     func lyricsText(tagArtistName: String, songTitle: String) -> String? {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT lyricsText
                     FROM \(Lyrics.self)
                     WHERE tagArtistName = \(tagArtistName) AND songTitle = \(songTitle)

--- a/Classes/Models/Data Store/ServerPlaylistStore.swift
+++ b/Classes/Models/Data Store/ServerPlaylistStore.swift
@@ -49,7 +49,7 @@ extension ServerPlaylist: FetchableRecord, PersistableRecord {
     }
     
     static func fetchSong(_ db: Database, serverId: Int, playlistId: Int, position: Int) throws -> Song? {
-        let sql: SQLLiteral = """
+        let sql: SQL = """
             SELECT *
             FROM \(Song.self)
             JOIN serverPlaylistSong
@@ -64,7 +64,7 @@ extension ServerPlaylist: FetchableRecord, PersistableRecord {
     }
     
     static func insertSong(_ db: Database, song: Song, position: Int, serverId: Int, playlistId: Int) throws {
-        let sql: SQLLiteral = """
+        let sql: SQL = """
             INSERT INTO serverPlaylistSong (serverId, serverPlaylistId, position, songId)
             VALUES (\(serverId), \(playlistId), \(position), \(song.id))
             """
@@ -83,7 +83,7 @@ extension Store {
                 }
                 
                 // Check if the songIds count matches the number of songs this album should have
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT songId
                     FROM serverPlaylistSong
                     WHERE serverId = \(serverId) AND serverPlaylistId = \(id)
@@ -246,7 +246,7 @@ extension Store {
     func songIds(serverId: Int, serverPlaylistId: Int) -> [String] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT songId
                     FROM serverPlaylistSong
                     WHERE serverId = \(serverId) AND serverPlaylistId = \(serverPlaylistId)

--- a/Classes/Models/Data Store/ServerStore.swift
+++ b/Classes/Models/Data Store/ServerStore.swift
@@ -81,7 +81,7 @@ extension Store {
     func deleteServer(id: Int) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                 DELETE FROM \(Server.self)
                 WHERE id = \(id)
                 """

--- a/Classes/Models/Data Store/TagAlbumStore.swift
+++ b/Classes/Models/Data Store/TagAlbumStore.swift
@@ -73,7 +73,7 @@ extension Store {
                 }
                 
                 // Check if the songIds count matches the number of songs this album should have
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT songId
                     FROM tagSongList
                     WHERE serverId = \(serverId) AND tagAlbumId = \(id)
@@ -117,7 +117,7 @@ extension Store {
 //    func tagAlbumIds(mediaFolderId: Int, orderBy: TagAlbum.Column = .name) -> [String] {
 //        do {
 //            return try serverDb.read { db in
-//                let sql: SQLLiteral = """
+//                let sql: SQL = """
 //                    SELECT id
 //                    FROM \(TagAlbum.self)
 //                    JOIN
@@ -135,7 +135,7 @@ extension Store {
     func tagAlbumIds(serverId: Int, tagArtistId: String, orderBy: TagAlbum.Column = .name) -> [String] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT id
                     FROM \(TagAlbum.self)
                     WHERE serverId = \(serverId) AND tagArtistId = \(tagArtistId)
@@ -176,7 +176,7 @@ extension Store {
     func songIds(serverId: Int, tagAlbumId: String) -> [String] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT songId
                     FROM tagSongList
                     WHERE serverId = \(serverId) AND tagAlbumId = \(tagAlbumId)
@@ -215,7 +215,7 @@ extension Store {
                 try song.save(db)
                 
                 // Insert song id into list cache
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO tagSongList
                     (serverId, tagAlbumId, songId)
                     VALUES (\(song.serverId), \(tagAlbumId), \(song.id))

--- a/Classes/Models/Data Store/TagArtistStore.swift
+++ b/Classes/Models/Data Store/TagArtistStore.swift
@@ -88,7 +88,7 @@ extension Store {
                 }
                 
                 // Check if the songIds count matches the number of songs this album should have
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT id
                     FROM tagAlbum
                     WHERE serverId = \(serverId) AND tagArtistId = \(id)
@@ -120,7 +120,7 @@ extension Store {
     func tagArtistIds(serverId: Int, mediaFolderId: Int) -> [String] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT tagArtistId
                     FROM tagArtistList
                     WHERE serverId = \(serverId) AND mediaFolderId = \(mediaFolderId)
@@ -152,7 +152,7 @@ extension Store {
                 try tagArtist.save(db)
                 
                 // Insert artist id into list cache
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO tagArtistList
                     (serverId, mediaFolderId, tagArtistId)
                     VALUES (\(tagArtist.serverId), \(mediaFolderId), \(tagArtist.id))
@@ -169,7 +169,7 @@ extension Store {
     func tagArtistSections(serverId: Int, mediaFolderId: Int) -> [TableSection] {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM tagArtistTableSection
                     WHERE serverId = \(serverId) AND mediaFolderId = \(mediaFolderId)
@@ -186,7 +186,7 @@ extension Store {
         do {
             return try pool.write { db in
                 // Insert artist id into list cache
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO tagArtistTableSection
                     (serverId, mediaFolderId, name, position, itemCount)
                     VALUES (\(section.serverId), \(section.mediaFolderId), \(section.name), \(section.position), \(section.itemCount))
@@ -203,7 +203,7 @@ extension Store {
     func tagArtistMetadata(serverId: Int, mediaFolderId: Int) -> RootListMetadata? {
         do {
             return try pool.read { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT *
                     FROM tagArtistListMetadata
                     WHERE serverId = \(serverId) AND mediaFolderId = \(mediaFolderId)
@@ -219,7 +219,7 @@ extension Store {
     func add(tagArtistListMetadata metadata: RootListMetadata) -> Bool {
         do {
             return try pool.write { db in
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     INSERT INTO tagArtistListMetadata
                     (serverId, mediaFolderId, itemCount, reloadDate)
                     VALUES (\(metadata.serverId), \(metadata.mediaFolderId), \(metadata.itemCount), \(metadata.reloadDate))
@@ -238,7 +238,7 @@ extension Store {
         do {
             return try pool.read { db in
                 let searchTerm = "%\(name)%"
-                let sql: SQLLiteral = """
+                let sql: SQL = """
                     SELECT tagArtistId
                     FROM tagArtistList
                     JOIN \(TagArtist.self)

--- a/Classes/Models/Singletons/PlayQueue.swift
+++ b/Classes/Models/Singletons/PlayQueue.swift
@@ -234,10 +234,11 @@ import CocoaLumberjackSwift
     
     @objc func shuffleToggle() {
        if isShuffle {
-           isShuffle = false
            if let shuffleCurrentSong = currentSong {
                print(shuffleCurrentSong)
+               isShuffle = false
                if let currentPosition = store.getSongPosition(localPlaylistId: LocalPlaylist.Default.playQueueId, songId: shuffleCurrentSong.id) {
+                   normalIndex = currentPosition
                    if let shuffleQueueCurrentSong = song(index: currentPosition) {
                        streamManager.removeAllStreams(except: shuffleQueueCurrentSong)
                        streamManager.fillStreamQueue(startDownload: true)
@@ -247,10 +248,10 @@ import CocoaLumberjackSwift
        } else {
            if store.createShuffleQueue(currentPosition: normalIndex) {
                shuffleIndex = 0
+               isShuffle = true
                if let currentSong = song(index: normalIndex) {
                    streamManager.removeAllStreams(except: currentSong)
                    streamManager.fillStreamQueue(startDownload: true)
-                   isShuffle = true
                }
            }
        }

--- a/Classes/Models/Singletons/PlayQueue.swift
+++ b/Classes/Models/Singletons/PlayQueue.swift
@@ -235,11 +235,23 @@ import CocoaLumberjackSwift
     @objc func shuffleToggle() {
        if isShuffle {
            isShuffle = false
-           playSong(position: 0)
+           if let shuffleCurrentSong = currentSong {
+               print(shuffleCurrentSong)
+               if let currentPosition = store.getSongPosition(localPlaylistId: LocalPlaylist.Default.playQueueId, songId: shuffleCurrentSong.id) {
+                   if let shuffleQueueCurrentSong = song(index: currentPosition) {
+                       streamManager.removeAllStreams(except: shuffleQueueCurrentSong)
+                       streamManager.fillStreamQueue(startDownload: true)
+                   }
+               }
+           }
        } else {
-           if store.createShuffleQueue() {
-               isShuffle = true
-               playSong(position: 0)
+           if store.createShuffleQueue(currentPosition: normalIndex) {
+               shuffleIndex = 0
+               if let currentSong = song(index: normalIndex) {
+                   streamManager.removeAllStreams(except: currentSong)
+                   streamManager.fillStreamQueue(startDownload: true)
+                   isShuffle = true
+               }
            }
        }
     }

--- a/Classes/View Controllers/Player/PlayerViewController.swift
+++ b/Classes/View Controllers/Player/PlayerViewController.swift
@@ -414,10 +414,10 @@ final class PlayerViewController: UIViewController {
             let message = playQueue.isShuffle ? "Unshuffling" : "Shuffling"
             HUD.show(message: message)
             DispatchQueue.userInitiated.async {
-                defer { HUD.hide() }
                 self.playQueue.shuffleToggle()
                 DispatchQueue.main.async {
                     self.updateShuffleButtonIcon()
+                    HUD.hide()
                 }
             }
         }


### PR DESCRIPTION
1. Update LocalPlaylistStore.createShuffleQueue to first insert the current playing song as the first song, then update the randomizeSql query to exclude that song.
<img width="846" alt="Screenshot 2024-09-20 at 5 18 59 PM" src="https://github.com/user-attachments/assets/c3d81245-6491-4792-bdf0-32ae9e7b8927">


2.  Update PlayQueue.shuffleToggle to not call playSong(position:) because that stops the music and manually set currentIndex to 0.
3. Instead tell StreamManager to removeAllStreams(except: Song) passing in the current playing song then call fillStreamQueue.
<img width="922" alt="Screenshot 2024-09-20 at 5 20 02 PM" src="https://github.com/user-attachments/assets/412ee5eb-2cfc-4ceb-a96c-fdb04afa4ccd">

5. Then also need to modify shuffleToggle so that when you switch back from shuffle to regular play queue, it should also not stop playing the music. It should be similar to the above but set currentIndex to the index of the current playing song in the play queue playlist.
<img width="878" alt="Screenshot 2024-09-20 at 5 21 54 PM" src="https://github.com/user-attachments/assets/697b48e5-bf04-45ed-99f8-0b7ac2591577">

6. Fix the PlayerViewController shuffle loader hiding the HUD in the right threath.

<img width="827" alt="Screenshot 2024-09-20 at 5 22 57 PM" src="https://github.com/user-attachments/assets/0a1eb3f4-43a8-498c-8d23-502688997505">


