### PR TITLE
Fix the nextsong playback with caching song enabled

### DIFF
--- a/Classes/Models/Stream Handlers/StreamManager.swift
+++ b/Classes/Models/Stream Handlers/StreamManager.swift
@@ -369,9 +369,7 @@ final class StreamManager {
     }
     
     @objc private func songPlaybackEnded() {
-        if settings.isSongCachingEnabled {
-            fillStreamQueue()
-        }
+        fillStreamQueue()
     }
 }
 
@@ -379,6 +377,7 @@ extension StreamManager: StreamHandlerDelegate {
     func streamHandlerStarted(handler: StreamHandler) {
         if handler.isTempCache {
             lastTempCachedSong = nil
+            player.startSong(handler.song, index: handlerStack.startIndex, offsetInBytes: handler.byteOffset, offsetInSeconds: handler.secondsOffset)
         }
     }
     


### PR DESCRIPTION
Following the thread of the algorithm the function start uses the `streamHandlerStarted(handler:self)` function and  this is the end of this thread , son I just give the play to the song. and now it works and it does not crash when slide forward the song on caching enabled setted.
<img width="435" alt="Screenshot 2024-10-22 at 5 21 04 PM" src="https://github.com/user-attachments/assets/dab3300c-7ad6-4547-91b0-349c389c3ef7">
