### PR TITLE
Bugfix/not properly hiding the delete button in the picker equalizer

### DIFF
--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
@@ -508,12 +508,6 @@ extension EqualizerViewController: UIPickerViewDelegate, UIPickerViewDataSource 
         presetPicker.reloadAllComponents()
         presetPicker.selectRow(effectDAO.selectedPresetIndex, inComponent: 0, animated: true)
         presetLabel.text = selectedPreset?.name as? String
-        
-        if effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId {
-            showSavePresetButton(animated: false)
-        } else if let isDefault = selectedPreset?.isDefault, isDefault {
-            showDeletePresetButton(animated: false)
-        }
     }
     
     @objc func showPresetPicker() {
@@ -575,8 +569,7 @@ extension EqualizerViewController: UIPickerViewDelegate, UIPickerViewDataSource 
             self.isPresetPickerShowing = false
         }
     }
-    
-    // TODO: Fix this logic, it's not properly hiding the delete button
+
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         effectDAO.selectPreset(index: row)
         

--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
@@ -505,9 +505,15 @@ extension EqualizerViewController: UIPickerViewDelegate, UIPickerViewDataSource 
     
     func updatePresetPicker() {
         let selectedPreset = effectDAO.selectedPreset
+        let isCustomPreset = effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId
+        let isDefaultPreset = effectDAO.selectedPreset?.isDefault ?? false
+        
         presetPicker.reloadAllComponents()
         presetPicker.selectRow(effectDAO.selectedPresetIndex, inComponent: 0, animated: true)
         presetLabel.text = selectedPreset?.name as? String
+        
+        updateSavePresetButton(isCustomPreset: isCustomPreset)
+        updateDeletePresetButton(isCustomPreset: isCustomPreset, isDefault: isDefaultPreset)
     }
     
     @objc func showPresetPicker() {

--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
@@ -573,20 +573,29 @@ extension EqualizerViewController: UIPickerViewDelegate, UIPickerViewDataSource 
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         effectDAO.selectPreset(index: row)
         
-        let isDefault = effectDAO.selectedPreset?.isDefault ?? false
-        if effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId && !isSavePresetButtonShowing {
-            showSavePresetButton(animated: true)
-        } else if effectDAO.selectedPresetId != BassEffectDAO.bassEffectTempCustomPresetId && isSavePresetButtonShowing {
-            hideSavePresetButton(animated: true)
-        }
-    
-        if effectDAO.selectedPresetId != BassEffectDAO.bassEffectTempCustomPresetId && !isDeletePresetButtonShowing && !isDefault {
-            showDeletePresetButton(animated: true)
-        } else if (effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId || isDefault) && isDeletePresetButtonShowing {
-            hideDeletePresetButton(animated: true)
-        }
+        let isCustomPreset = effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId
+        let isDefaultPreset = effectDAO.selectedPreset?.isDefault ?? false
+        
+        updateSavePresetButton(isCustomPreset: isCustomPreset)
+        updateDeletePresetButton(isCustomPreset: isCustomPreset, isDefault: isDefaultPreset)
         
         updatePresetPicker()
+    }
+    
+    private func updateSavePresetButton(isCustomPreset: Bool) {
+        if isCustomPreset && !isSavePresetButtonShowing {
+            showSavePresetButton(animated: true)
+        } else if !isCustomPreset && isSavePresetButtonShowing {
+            hideSavePresetButton(animated: true)
+        }
+    }
+
+    private func updateDeletePresetButton(isCustomPreset: Bool, isDefault: Bool) {
+        if !isCustomPreset && !isDeletePresetButtonShowing && !isDefault {
+            showDeletePresetButton(animated: true)
+        } else if (isCustomPreset || isDefault) && isDeletePresetButtonShowing {
+            hideDeletePresetButton(animated: true)
+        }
     }
     
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {


### PR DESCRIPTION
Now, the delete button is hidden in the picker when on presets. I removed redundant code and implemented handler methods for showing or hiding the save and delete buttons for more readable and scalable code.

https://github.com/user-attachments/assets/0267d931-62fb-43f7-9864-5e411238fb52



