### PR TITLE
Bugfix/the eq points do now show if the player has not been started yet

### DIFF
--- a/Classes/Audio Engine/BassEqualizer.swift
+++ b/Classes/Audio Engine/BassEqualizer.swift
@@ -143,6 +143,7 @@ private let equalizerGainReduction: Float = 0.45
     
     @objc(removeEqualizerValue:)
     func removeEqualizerValue(value: BassParamEqValue) {
+        guard value.arrayIndex >= eqValues.count else { return }
         print("removeEqualizerValue");
         if isEqActive && channel > 0 {
             // Disable the effect channel

--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerPointView.swift
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerPointView.swift
@@ -53,10 +53,13 @@ func percentY(gain: Float) -> CGFloat {
     @objc init(point: CGPoint, parentSize: CGSize) {
         let p = BASS_DX8_PARAMEQ(fCenter: 0, fBandwidth: Float(defaultBandwidth), fGain: 0)
         self._eqValue = BassParamEqValue(parameters: p)
-        self.position = CGPoint(x: point.x / parentSize.width, y: point.y / parentSize.height)
+        
+        // Scale point to parentSize
+        let scaledPoint = CGPoint(x: point.x * parentSize.width, y: point.y * parentSize.height)
+        self.position = CGPoint(x: point.x, y: point.y)
         self.parentSize = parentSize
         super.init(frame: CGRect(x: 0, y: 0, width: defaultWidth, height: defaultHeight))
-        self.center = point
+        self.center = scaledPoint  // Set scaled point as center
         self.image = UIImage(named: "eqView")
         self.isUserInteractionEnabled = true
     }

--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
@@ -251,6 +251,13 @@ import Resolver
             return eqView
         }
         
+        if equalizerPointViews.isEmpty {
+            for eqValue in effectDAO.selectedPreset?.values ?? [] {
+                let eqView = EqualizerPointView(point: eqValue, parentSize: equalizerView?.frame.size ?? .zero)
+                view.insertSubview(eqView, aboveSubview: equalizerPath)
+                equalizerPointViews.append(eqView)
+            }
+        }
         createAndDrawEqualizerPath()
     }
     
@@ -427,13 +434,13 @@ import Resolver
             
             // Only create EQ points in portrait mode when EQ is visible
             if UIDevice.isPad || UIApplication.orientation.isPortrait {
-                // Add a point
-                
-                // Find the tap point
-                let point = touch.location(in: eqView)
+
+                // Normalize tap point
+                let rawPoint = touch.location(in: eqView)
+                let normalizedPoint = CGPoint(x: rawPoint.x / eqView.bounds.width, y: rawPoint.y / eqView.bounds.height)
                 
                 // Create the eq view
-                let pointView = EqualizerPointView(point: point, parentSize: eqView.bounds.size)
+                let pointView = EqualizerPointView(point: normalizedPoint, parentSize: eqView.bounds.size)
                 let eqValue = BassPlayer.shared.equalizer.addEqualizerValue(value: pointView.eqValue.parameters)
                 pointView.eqValue = eqValue
 

--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
@@ -512,15 +512,15 @@ extension EqualizerViewController: UIPickerViewDelegate, UIPickerViewDataSource 
     
     func updatePresetPicker() {
         let selectedPreset = effectDAO.selectedPreset
+        let isCustomPreset = effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId
+        let isDefaultPreset = effectDAO.selectedPreset?.isDefault ?? false
+        
         presetPicker.reloadAllComponents()
         presetPicker.selectRow(effectDAO.selectedPresetIndex, inComponent: 0, animated: true)
         presetLabel.text = selectedPreset?.name as? String
         
-        if effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId {
-            showSavePresetButton(animated: false)
-        } else if let isDefault = selectedPreset?.isDefault, isDefault {
-            showDeletePresetButton(animated: false)
-        }
+        updateSavePresetButton(isCustomPreset: isCustomPreset)
+        updateDeletePresetButton(isCustomPreset: isCustomPreset, isDefault: isDefaultPreset)
     }
     
     @objc func showPresetPicker() {
@@ -582,25 +582,33 @@ extension EqualizerViewController: UIPickerViewDelegate, UIPickerViewDataSource 
             self.isPresetPickerShowing = false
         }
     }
-    
-    // TODO: Fix this logic, it's not properly hiding the delete button
+
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         effectDAO.selectPreset(index: row)
         
-        let isDefault = effectDAO.selectedPreset?.isDefault ?? false
-        if effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId && !isSavePresetButtonShowing {
-            showSavePresetButton(animated: true)
-        } else if effectDAO.selectedPresetId != BassEffectDAO.bassEffectTempCustomPresetId && isSavePresetButtonShowing {
-            hideSavePresetButton(animated: true)
-        }
-    
-        if effectDAO.selectedPresetId != BassEffectDAO.bassEffectTempCustomPresetId && !isDeletePresetButtonShowing && !isDefault {
-            showDeletePresetButton(animated: true)
-        } else if (effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId || isDefault) && isDeletePresetButtonShowing {
-            hideDeletePresetButton(animated: true)
-        }
+        let isCustomPreset = effectDAO.selectedPresetId == BassEffectDAO.bassEffectTempCustomPresetId
+        let isDefaultPreset = effectDAO.selectedPreset?.isDefault ?? false
+        
+        updateSavePresetButton(isCustomPreset: isCustomPreset)
+        updateDeletePresetButton(isCustomPreset: isCustomPreset, isDefault: isDefaultPreset)
         
         updatePresetPicker()
+    }
+    
+    private func updateSavePresetButton(isCustomPreset: Bool) {
+        if isCustomPreset && !isSavePresetButtonShowing {
+            showSavePresetButton(animated: true)
+        } else if !isCustomPreset && isSavePresetButtonShowing {
+            hideSavePresetButton(animated: true)
+        }
+    }
+
+    private func updateDeletePresetButton(isCustomPreset: Bool, isDefault: Bool) {
+        if !isCustomPreset && !isDeletePresetButtonShowing && !isDefault {
+            showDeletePresetButton(animated: true)
+        } else if (isCustomPreset || isDefault) && isDeletePresetButtonShowing {
+            hideDeletePresetButton(animated: true)
+        }
     }
     
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {


### PR DESCRIPTION
The equalizer now is showing the presets when the player is off, I have to make an rebase from the master, of the last PR. so ignore please th update preset picker method changes. and yo can remove or add points but it is not working for the real equalizer.
![simulator_screenshot_A87A1081-C81D-499E-B165-1C68B29B93C5](https://github.com/user-attachments/assets/f9830223-16b4-4b61-87de-f799e04755cd)
