### PR TITLE
Bugfix/you can press eq on button if player has not started yet but cannot press eq off

### DIFF
--- a/Classes/Audio Engine/BassEqualizer.swift
+++ b/Classes/Audio Engine/BassEqualizer.swift
@@ -185,24 +185,34 @@ private let equalizerGainReduction: Float = 0.45
     
     @objc @discardableResult
     func toggleEqualizer() -> Bool {
+        // Update the state of the equalizer
         settings.isEqualizerOn = !isEqActive
         
         if isEqActive {
-            clearEqualizerValues()
-        } else {
-            // TODO: See if this lock and copy is necessary
-            let values = eqValuesLock.sync {
-                let values = eqValues
-                return values
-            }
-//            eqValuesLock.lock()
-//            let values = eqValues
-//            eqValuesLock.unlock()
-            applyEqualizerValues(values: values)
+            deactivateEqualizer()
+        } else{
+            activateEqualizer()
         }
+        
+        // Set the gain level
         gain = settings.gainMultiplier
         
         return !isEqActive
+    }
+    
+    private func deactivateEqualizer() {
+        clearEqualizerValues()
+        isEqActive = false
+    }
+    
+    private func activateEqualizer() {
+        if settings.isPlaying {
+            let values = eqValuesLock.sync { eqValues }
+            applyEqualizerValues(values: values)
+        } else {
+            // Even is not playing force to activate the equalizer
+            isEqActive = true
+        }
     }
     
     @objc func createVolumeFx() {

--- a/Classes/Audio Engine/BassEqualizer.swift
+++ b/Classes/Audio Engine/BassEqualizer.swift
@@ -46,6 +46,8 @@ private let equalizerGainReduction: Float = 0.45
 //        return values
     }
     
+    var isPlayerInitialized: Bool = false
+    
     private var eqHandles = [HFX]()
     private var eqValues = [BassParamEqValue]()
     private let eqValuesLock = NSRecursiveLock()
@@ -206,11 +208,11 @@ private let equalizerGainReduction: Float = 0.45
     }
     
     private func activateEqualizer() {
-        if settings.isPlaying {
+        if isPlayerInitialized {
             let values = eqValuesLock.sync { eqValues }
             applyEqualizerValues(values: values)
         } else {
-            // Even is not playing force to activate the equalizer
+            // Even the Player is off, force to activate the equalizer
             isEqActive = true
         }
     }

--- a/Classes/Audio Engine/BassPlayer.swift
+++ b/Classes/Audio Engine/BassPlayer.swift
@@ -193,6 +193,8 @@ private let bassStreamMinFilesizeToFail = 15 * 1024 * 1024 // 15 MB
         
         // Add limiter to prevent distortion
         equalizer.createLimiterFx()
+        
+        equalizer.isPlayerInitialized = true
     }
     
     func cleanup() {

--- a/Classes/Models/Singletons/SavedSettings.swift
+++ b/Classes/Models/Singletons/SavedSettings.swift
@@ -125,9 +125,6 @@ final class SavedSettings {
         }
     }
     
-    @UserDefault(key: .isPlaying, defaultValue: false)
-    var isPlaying: Bool
-    
     @UserDefault(key: .enableSongCachingSetting, defaultValue: true)
     var isSongCachingEnabled: Bool
     

--- a/Classes/Models/Singletons/SavedSettings.swift
+++ b/Classes/Models/Singletons/SavedSettings.swift
@@ -125,6 +125,9 @@ final class SavedSettings {
         }
     }
     
+    @UserDefault(key: .isPlaying, defaultValue: false)
+    var isPlaying: Bool
+    
     @UserDefault(key: .enableSongCachingSetting, defaultValue: true)
     var isSongCachingEnabled: Bool
     

--- a/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
+++ b/Classes/View Controllers/Player/EQ and Visualizer/EqualizerViewController.swift
@@ -279,6 +279,12 @@ import Resolver
         navigationController?.navigationBar.isHidden = false
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        navigationController?.popToRootViewController(animated: false)
+    }
+    
     func hideSavePresetButton(animated: Bool) {
         isSavePresetButtonShowing = false
         if animated {


### PR DESCRIPTION
The bug is about the `isEqActive` variable is not updating to true in the `toogleEquializer()` becasue there is no values into the equalizer because the player is off. so I just add true to this variable even it is not playing, and I refactored  this function for more readable an scalable perform creating two methods `deactivateEqualizer()` and `activateEqualizer()` Fixed!.

